### PR TITLE
feat: Add "Piano Virtuoso" visualization effect

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -18,6 +18,7 @@ export enum VisualizationType {
     PIXEL_SORT = '像素排序 (Pixel Sort)',
     REPULSOR_FIELD = '排斥力場',
     AUDIO_LANDSCAPE = '音訊地貌',
+    PIANO_VIRTUOSO = '鋼琴演奏家',
 }
 
 export enum FontType {


### PR DESCRIPTION
This commit introduces a new visualization effect called "Piano Virtuoso" (鋼琴演奏家).

The new effect features a piano keyboard at the bottom of the screen. The keys react to the audio's frequency data, giving the impression of being pressed in time with the music. When keys are pressed, musical note particles (♪, ♫) are generated and float upwards, creating a dynamic and engaging visual experience.

Changes include:
- Added `PIANO_VIRTUOSO` to the `VisualizationType` enum in `types.ts`.
- Implemented the `drawPianoVirtuoso` function in `components/AudioVisualizer.tsx` to handle the rendering of the keyboard and note particles.
- Added particle generation and management logic for the new effect within the main animation loop in `components/AudioVisualizer.tsx`.
- Registered the new effect in the `VISUALIZATION_MAP`.